### PR TITLE
Add HttpError type and use it for generic http request methods

### DIFF
--- a/src/apps.rs
+++ b/src/apps.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use chrono::{DateTime, Utc};
-use fn_error_context::context;
 use serde::Deserialize;
 use serde_with::skip_serializing_none;
 use uuid::Uuid;
@@ -17,15 +17,13 @@ pub struct Application {
 }
 
 impl Client {
-    #[context("Getting application")]
     pub async fn get_app(&self, app_id: &Uuid) -> anyhow::Result<Application> {
         let path = format!("/v1/apps/{}", app_id);
-        self.get(&path, Option::<&()>::None).await
+        self.get(&path, Option::<&()>::None).await.context("Getting application")
     }
 
-    #[context("Getting applications")]
     pub async fn get_apps(&self, org_id: &Uuid) -> anyhow::Result<Vec<Application>> {
         let path = format!("/v1/orgs/{}/apps", org_id);
-        self.get(&path, Option::<&()>::None).await
+        self.get(&path, Option::<&()>::None).await.context("Getting applications")
     }
 }

--- a/src/cameras.rs
+++ b/src/cameras.rs
@@ -73,44 +73,48 @@ pub struct NewLinkedCamera {
 impl Client {
     #[context("Reading camera {}", camera_id)]
     pub async fn read_camera(&self, camera_id: Uuid) -> anyhow::Result<Camera> {
-        self.get(&format!("/v1/apps/{}/cameras/{}", self.application_id()?, camera_id), None::<&()>)
-            .await
+        Ok(self
+            .get(&format!("/v1/apps/{}/cameras/{}", self.application_id()?, camera_id), None::<&()>)
+            .await?)
     }
 
     #[context("Listing cameras")]
     pub async fn list_cameras(&self) -> anyhow::Result<Vec<Camera>> {
-        self.get(&format!("/v1/apps/{}/cameras", self.application_id()?), None::<&()>).await
+        Ok(self.get(&format!("/v1/apps/{}/cameras", self.application_id()?), None::<&()>).await?)
     }
 
     #[context("Listing camera streams")]
     pub async fn list_camera_streams(&self, camera_id: Uuid) -> anyhow::Result<Vec<Stream>> {
-        self.get(
-            &format!("/v1/apps/{}/cameras/{}/streams", self.application_id()?, camera_id),
-            None::<&()>,
-        )
-        .await
+        Ok(self
+            .get(
+                &format!("/v1/apps/{}/cameras/{}/streams", self.application_id()?, camera_id),
+                None::<&()>,
+            )
+            .await?)
     }
 
     #[context("Setting cameras statuses")]
     pub async fn set_cameras_statuses(&self, cameras: &[CameraData]) -> anyhow::Result<()> {
-        self.put_without_response_deserialization(
-            &format!(
-                "/v1/apps/{}/devices/{}/cameras_statuses",
-                self.application_id()?,
-                self.gateway_id()?
-            ),
-            &cameras,
-        )
-        .await
+        Ok(self
+            .put_without_response_deserialization(
+                &format!(
+                    "/v1/apps/{}/devices/{}/cameras_statuses",
+                    self.application_id()?,
+                    self.gateway_id()?
+                ),
+                &cameras,
+            )
+            .await?)
     }
 
     #[context("Setting camera status")]
     pub async fn set_camera_status(&self, camera_id: Uuid, status: &str) -> anyhow::Result<()> {
-        self.put_text(
-            &format!("/v1/apps/{}/cameras/{}/status", self.application_id()?, camera_id),
-            status,
-        )
-        .await
+        Ok(self
+            .put_text(
+                &format!("/v1/apps/{}/cameras/{}/status", self.application_id()?, camera_id),
+                status,
+            )
+            .await?)
     }
 }
 

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -84,13 +84,13 @@ impl Client {
     #[context("Getting deployments")]
     pub async fn get_deployments(&self, filter: &ListParams) -> anyhow::Result<Vec<Deployment>> {
         let path = format!("/v1/apps/{}/deployments", self.application_id()?);
-        self.get(&path, Some(&filter)).await
+        Ok(self.get(&path, Some(&filter)).await?)
     }
 
     #[context("Creating deployment")]
     pub async fn create_deployment(&self, data: &NewDeployment) -> anyhow::Result<Deployment> {
         let path = format!("/v1/apps/{}/deployments", self.application_id()?);
-        self.post(&path, data).await
+        Ok(self.post(&path, data).await?)
     }
 
     // FIXME: Make method naming consistent for all methods. It is either create/read/update/delete
@@ -98,7 +98,7 @@ impl Client {
     #[context("Getting deployment {}", id)]
     pub async fn get_deployment(&self, id: Uuid) -> anyhow::Result<Deployment> {
         let path = format!("/v1/apps/{}/deployments/{}", self.application_id()?, id);
-        self.get(&path, None::<&()>).await
+        Ok(self.get(&path, None::<&()>).await?)
     }
 
     #[context("Updating deployment {}", id)]
@@ -108,19 +108,19 @@ impl Client {
         data: &DeploymentData,
     ) -> anyhow::Result<Deployment> {
         let path = format!("/v1/apps/{}/deployments/{}", self.application_id()?, id);
-        self.put(&path, data).await
+        Ok(self.put(&path, data).await?)
     }
 
     #[context("Deleting deployment {}", id)]
     pub async fn delete_deployment(&self, id: Uuid) -> anyhow::Result<()> {
         let path = format!("/v1/apps/{}/deployments/{}", self.application_id()?, id);
-        self.delete(&path).await
+        Ok(self.delete(&path).await?)
     }
 
     #[context("Getting pipeline for deployment {}", id)]
     pub async fn get_deployment_definition(&self, id: Uuid) -> anyhow::Result<Pipeline> {
         let path = format!("/v1/apps/{}/deployments/{}/definition", self.application_id()?, id);
-        self.get(&path, None::<&()>).await
+        Ok(self.get(&path, None::<&()>).await?)
     }
 
     #[context("Starting deployment {}", id)]

--- a/src/discovery_requests.rs
+++ b/src/discovery_requests.rs
@@ -38,15 +38,16 @@ impl Client {
         request_id: Uuid,
         data: &DiscoveryRequestData,
     ) -> anyhow::Result<()> {
-        self.put_without_response_deserialization(
-            &format!(
-                "/v1/apps/{}/devices/{}/discovery_request/{}",
-                self.application_id()?,
-                self.gateway_id()?,
-                request_id
-            ),
-            data,
-        )
-        .await
+        Ok(self
+            .put_without_response_deserialization(
+                &format!(
+                    "/v1/apps/{}/devices/{}/discovery_request/{}",
+                    self.application_id()?,
+                    self.gateway_id()?,
+                    request_id
+                ),
+                data,
+            )
+            .await?)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,85 @@
+use std::fmt;
+
+use reqwest::Method;
+
+#[derive(Debug)]
+pub struct HttpError {
+    inner: InnerHttpError,
+    method: Method,
+    path: String,
+}
+
+impl HttpError {
+    pub fn request_method(&self) -> &Method {
+        &self.method
+    }
+
+    pub fn request_path(&self) -> &str {
+        &self.path
+    }
+
+    /// If the error comes from `reqwest`, return the inner `reqwest::Error`.
+    pub fn to_reqwest_error(&self) -> Option<&reqwest::Error> {
+        match &self.inner {
+            InnerHttpError::Url(_) | InnerHttpError::Query(_) => None,
+            InnerHttpError::Reqwest(e) => Some(e),
+        }
+    }
+
+    // Url and Query accessors left out because there's no use case yet
+}
+
+#[derive(Debug)]
+enum InnerHttpError {
+    Url(url::ParseError),
+    Query(serde_urlencoded::ser::Error),
+    Reqwest(reqwest::Error),
+}
+
+pub(crate) trait ResultExt<T> {
+    fn http_context(self, method: Method, path: &str) -> Result<T, HttpError>;
+}
+
+impl fmt::Display for InnerHttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InnerHttpError::Url(e) => e.fmt(f),
+            InnerHttpError::Query(e) => e.fmt(f),
+            InnerHttpError::Reqwest(e) => e.fmt(f),
+        }
+    }
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} request to `{}` failed: {}", self.method, self.path, self.inner)
+    }
+}
+
+impl std::error::Error for HttpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(match &self.inner {
+            InnerHttpError::Url(e) => e,
+            InnerHttpError::Query(e) => e,
+            InnerHttpError::Reqwest(e) => e,
+        })
+    }
+}
+
+impl<T> ResultExt<T> for Result<T, url::ParseError> {
+    fn http_context(self, method: Method, path: &str) -> Result<T, HttpError> {
+        self.map_err(|e| HttpError { inner: InnerHttpError::Url(e), method, path: path.into() })
+    }
+}
+
+impl<T> ResultExt<T> for Result<T, serde_urlencoded::ser::Error> {
+    fn http_context(self, method: Method, path: &str) -> Result<T, HttpError> {
+        self.map_err(|e| HttpError { inner: InnerHttpError::Query(e), method, path: path.into() })
+    }
+}
+
+impl<T> ResultExt<T> for Result<T, reqwest::Error> {
+    fn http_context(self, method: Method, path: &str) -> Result<T, HttpError> {
+        self.map_err(|e| HttpError { inner: InnerHttpError::Reqwest(e), method, path: path.into() })
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -41,6 +41,6 @@ pub struct Event {
 impl Client {
     #[context("Creating event")]
     pub async fn create_event(&self, event: &EventData) -> anyhow::Result<Event> {
-        self.post(&format!("/v1/apps/{}/events", self.application_id()?), event).await
+        Ok(self.post(&format!("/v1/apps/{}/events", self.application_id()?), event).await?)
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -77,26 +77,30 @@ pub struct ListParams {
 impl Client {
     #[context("Listing files")]
     pub async fn list_files(&self, params: Option<&ListParams>) -> anyhow::Result<Vec<File>> {
-        self.get(&format!("/v1/apps/{}/files", self.application_id()?), params).await
+        Ok(self.get(&format!("/v1/apps/{}/files", self.application_id()?), params).await?)
     }
 
     #[context("Creating file {}", file_data.name)]
     pub async fn create_file(&self, file_data: &FileData) -> anyhow::Result<File> {
-        self.post(&format!("/v1/apps/{}/files", self.application_id()?), file_data).await
+        Ok(self.post(&format!("/v1/apps/{}/files", self.application_id()?), file_data).await?)
     }
 
     #[context("Reading file {}", id)]
     pub async fn read_file(&self, id: Uuid) -> anyhow::Result<File> {
-        self.get(&format!("/v1/apps/{}/files/{}", self.application_id()?, id), None::<&()>).await
+        Ok(self
+            .get(&format!("/v1/apps/{}/files/{}", self.application_id()?, id), None::<&()>)
+            .await?)
     }
 
     #[context("Updating file {}", id)]
     pub async fn update_file(&self, id: Uuid, file_data: &FileData) -> anyhow::Result<File> {
-        self.put(&format!("/v1/apps/{}/files/{}", self.application_id()?, id), file_data).await
+        Ok(self
+            .put(&format!("/v1/apps/{}/files/{}", self.application_id()?, id), file_data)
+            .await?)
     }
 
     #[context("Deleting file {}", id)]
     pub async fn delete_file(&self, id: Uuid) -> anyhow::Result<()> {
-        self.delete(&format!("/v1/apps/{}/files/{}", self.application_id()?, id)).await
+        Ok(self.delete(&format!("/v1/apps/{}/files/{}", self.application_id()?, id)).await?)
     }
 }

--- a/src/gateways.rs
+++ b/src/gateways.rs
@@ -49,24 +49,34 @@ impl Client {
         application_id: Uuid,
         gateway: &NewGateway,
     ) -> anyhow::Result<Gateway> {
-        self.post(&format!("/v1/apps/{}/devices", application_id), gateway).await
+        Ok(self.post(&format!("/v1/apps/{}/devices", application_id), gateway).await?)
     }
 
     #[context("Updating local gateway IP")]
     pub async fn update_gateway_ip_local(&self, ip: &IpAddr) -> anyhow::Result<()> {
-        self.put_text(
-            &format!("/v1/apps/{}/devices/{}/ip_local", self.application_id()?, self.gateway_id()?),
-            ip,
-        )
-        .await
+        Ok(self
+            .put_text(
+                &format!(
+                    "/v1/apps/{}/devices/{}/ip_local",
+                    self.application_id()?,
+                    self.gateway_id()?
+                ),
+                ip,
+            )
+            .await?)
     }
 
     #[context("Updating external gateway IP")]
     pub async fn update_gateway_ip_ext(&self, ip: &IpAddr) -> anyhow::Result<()> {
-        self.put_text(
-            &format!("/v1/apps/{}/devices/{}/ip_ext", self.application_id()?, self.gateway_id()?),
-            ip,
-        )
-        .await
+        Ok(self
+            .put_text(
+                &format!(
+                    "/v1/apps/{}/devices/{}/ip_ext",
+                    self.application_id()?,
+                    self.gateway_id()?
+                ),
+                ip,
+            )
+            .await?)
     }
 }

--- a/src/orgs.rs
+++ b/src/orgs.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use chrono::{DateTime, Utc};
-use fn_error_context::context;
 use serde::Deserialize;
 use serde_with::skip_serializing_none;
 use uuid::Uuid;
@@ -17,8 +17,7 @@ pub struct Organization {
 }
 
 impl Client {
-    #[context("Getting organizations")]
     pub async fn get_orgs(&self) -> anyhow::Result<Vec<Organization>> {
-        self.get("/v1/orgs", Option::<&()>::None).await
+        self.get("/v1/orgs", Option::<&()>::None).await.context("Getting organizations")
     }
 }

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -17,20 +17,22 @@ pub struct SnapshotResponse {
 impl Client {
     #[context("Taking camera snapshot")]
     pub async fn take_camera_snapshot(&self, camera_id: Uuid) -> anyhow::Result<SnapshotResponse> {
-        self.post(
-            &format!("/v1/apps/{}/cameras/{}/snapshot", self.application_id()?, camera_id),
-            &SnapshotParams::default(),
-        )
-        .await
+        Ok(self
+            .post(
+                &format!("/v1/apps/{}/cameras/{}/snapshot", self.application_id()?, camera_id),
+                &SnapshotParams::default(),
+            )
+            .await?)
     }
 
     #[context("Taking stream snapshot")]
     pub async fn take_stream_snapshot(&self, stream_id: Uuid) -> anyhow::Result<SnapshotResponse> {
-        self.post(
-            &format!("/v1/apps/{}/streams/{}/snapshot", self.application_id()?, stream_id),
-            &SnapshotParams::default(),
-        )
-        .await
+        Ok(self
+            .post(
+                &format!("/v1/apps/{}/streams/{}/snapshot", self.application_id()?, stream_id),
+                &SnapshotParams::default(),
+            )
+            .await?)
     }
 
     #[context("Setting camera snapshot file ID")]
@@ -39,11 +41,16 @@ impl Client {
         camera_id: Uuid,
         snapshot_file_id: Uuid,
     ) -> anyhow::Result<()> {
-        self.put_text(
-            &format!("/v1/apps/{}/cameras/{}/snapshot_file_id", self.application_id()?, camera_id),
-            &snapshot_file_id.to_hyphenated(),
-        )
-        .await
+        Ok(self
+            .put_text(
+                &format!(
+                    "/v1/apps/{}/cameras/{}/snapshot_file_id",
+                    self.application_id()?,
+                    camera_id
+                ),
+                &snapshot_file_id.to_hyphenated(),
+            )
+            .await?)
     }
 
     #[context("Setting stream snapshot file ID")]
@@ -52,10 +59,15 @@ impl Client {
         stream_id: Uuid,
         snapshot_file_id: Uuid,
     ) -> anyhow::Result<()> {
-        self.put_text(
-            &format!("/v1/apps/{}/streams/{}/snapshot_file_id", self.application_id()?, stream_id),
-            &snapshot_file_id.to_hyphenated(),
-        )
-        .await
+        Ok(self
+            .put_text(
+                &format!(
+                    "/v1/apps/{}/streams/{}/snapshot_file_id",
+                    self.application_id()?,
+                    stream_id
+                ),
+                &snapshot_file_id.to_hyphenated(),
+            )
+            .await?)
     }
 }

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -45,12 +45,13 @@ pub struct Stream {
 impl Client {
     #[context("Creating a stream (name={:?})", stream.name)]
     pub async fn create_stream(&self, stream: &StreamData) -> anyhow::Result<Stream> {
-        self.post(&format!("/v1/apps/{}/streams", self.application_id()?), stream).await
+        Ok(self.post(&format!("/v1/apps/{}/streams", self.application_id()?), stream).await?)
     }
 
     #[context("Reading stream {}", stream_id)]
     pub async fn read_stream(&self, stream_id: Uuid) -> anyhow::Result<Stream> {
-        self.get(&format!("/v1/apps/{}/streams/{}", self.application_id()?, stream_id), None::<&()>)
-            .await
+        Ok(self
+            .get(&format!("/v1/apps/{}/streams/{}", self.application_id()?, stream_id), None::<&()>)
+            .await?)
     }
 }


### PR DESCRIPTION
This allows downstream code that uses them (directly) to check error details without relying on downcasting.

The reason I don't like downcasting is that it will silently stop working if we change the implementation here, for example by upgrading the reqwest version but not (immediately) doing the same version upgrade in downstream code.