### PR TITLE
Add HTTP status code to ErrorDetails

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use reqwest::{Method, Response};
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
@@ -75,17 +77,23 @@ impl ErrorDetails {
     }
 }
 
+impl fmt::Display for ErrorDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} request to `{}` failed", self.method, self.path)
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("{} request to `{}` failed: {0}", .1.method, .1.path)]
+    #[error("{1}: {0}")]
     Url(#[source] url::ParseError, ErrorDetails),
-    #[error("{} request to `{}` failed: {0}", .1.method, .1.path)]
+    #[error("{1}: {0}")]
     Query(#[source] serde_urlencoded::ser::Error, ErrorDetails),
-    #[error("{} request to `{}` failed: {0}", .1.method, .1.path)]
+    #[error("{1}: {0}")]
     Reqwest(#[source] reqwest::Error, ErrorDetails),
-    #[error("{} request to `{}` failed: {0}", .1.method, .1.path)]
+    #[error("{1}: {0}")]
     Api(#[source] ApiError, ErrorDetails),
-    #[error("{} request to `{}` failed: {0}", .1.method, .1.path)]
+    #[error("{1}: {0}")]
     ErrorDeserialization(#[source] reqwest::Error, ErrorDetails),
     #[error("Application id is missing")]
     ApplicationIdMissing,

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,7 +69,7 @@ pub(crate) async fn verify_response(
 
         match serde_json::from_slice(&body) {
             Ok(api_error) => return Err(Error::Api(api_error, details)),
-            Err(e) => return Err(Error::ErrorDeserialization(e, details)),
+            Err(e) => return Err(Error::Deserialization(e, details)),
         }
     }
 
@@ -117,7 +117,7 @@ pub enum Error {
     #[error("{0}")]
     ApiEmptyResponse(ErrorDetails),
     #[error("{1}: {0}")]
-    ErrorDeserialization(#[source] serde_json::Error, ErrorDetails),
+    Deserialization(#[source] serde_json::Error, ErrorDetails),
     #[error("Application id is missing")]
     ApplicationIdMissing,
     #[error("Gateway id is missing")]


### PR DESCRIPTION
I wanted to look into an error I got in my lumeod but apparently API server didn't respond with JSON and so the error message isn't super useful. This most likely means that it was an internal server error, but we don't actually know since we don't currently store the status code in case of response deserialization errors.

With this change, the status code is added to the error we log, if the error happened after receiving a response.