### PR TITLE
Replace use of old gateway routes

### DIFF
--- a/lumeo_api_client/src/cameras.rs
+++ b/lumeo_api_client/src/cameras.rs
@@ -95,7 +95,7 @@ impl Client {
     pub async fn set_cameras_statuses(&self, cameras: &[CameraData]) -> Result<()> {
         self.put_without_response_deserialization(
             &format!(
-                "/v1/apps/{}/devices/{}/cameras_statuses",
+                "/v1/apps/{}/gateways/{}/cameras_statuses",
                 self.application_id()?,
                 self.gateway_id()?
             ),

--- a/lumeo_api_client/src/discovery_requests.rs
+++ b/lumeo_api_client/src/discovery_requests.rs
@@ -39,7 +39,7 @@ impl Client {
     ) -> Result<()> {
         self.put_without_response_deserialization(
             &format!(
-                "/v1/apps/{}/devices/{}/discovery_request/{}",
+                "/v1/apps/{}/gateways/{}/discovery_request/{}",
                 self.application_id()?,
                 self.gateway_id()?,
                 request_id

--- a/lumeo_api_client/src/gateways.rs
+++ b/lumeo_api_client/src/gateways.rs
@@ -48,13 +48,13 @@ impl Client {
         application_id: Uuid,
         gateway: &NewGateway,
     ) -> Result<Gateway> {
-        self.post(&format!("/v1/apps/{}/devices", application_id), gateway).await
+        self.post(&format!("/v1/apps/{}/gateways", application_id), gateway).await
     }
 
     pub async fn list_linked_cameras(&self) -> Result<Vec<Camera>> {
         self.get(
             &format!(
-                "/v1/apps/{}/devices/{}/linked_cameras",
+                "/v1/apps/{}/gateways/{}/linked_cameras",
                 self.application_id()?,
                 self.gateway_id()?
             ),
@@ -65,7 +65,11 @@ impl Client {
 
     pub async fn update_gateway_ip_local(&self, ip: &IpAddr) -> Result<()> {
         self.put_text(
-            &format!("/v1/apps/{}/devices/{}/ip_local", self.application_id()?, self.gateway_id()?),
+            &format!(
+                "/v1/apps/{}/gateways/{}/ip_local",
+                self.application_id()?,
+                self.gateway_id()?
+            ),
             ip,
         )
         .await
@@ -73,7 +77,7 @@ impl Client {
 
     pub async fn update_gateway_ip_ext(&self, ip: &IpAddr) -> Result<()> {
         self.put_text(
-            &format!("/v1/apps/{}/devices/{}/ip_ext", self.application_id()?, self.gateway_id()?),
+            &format!("/v1/apps/{}/gateways/{}/ip_ext", self.application_id()?, self.gateway_id()?),
             ip,
         )
         .await


### PR DESCRIPTION
`/devices/` routes are deprecated in favor of equivalent `/gateways/` routes.