### PR TITLE
Add file streams

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,15 +12,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           default: true
           profile: minimal
       - name: Build
-        run: cargo build --verbose
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
       - name: Run tests
-        run: cargo test --verbose
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
 
   lint:
     runs-on: ubuntu-latest
@@ -28,6 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -35,6 +43,35 @@ jobs:
           profile: minimal
           components: clippy, rustfmt
       - name: Catch common mistakes
-        run: cargo clippy --tests -- -Dwarnings
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests --all-features -- -Dwarnings
       - name: Check formatting
-        run: cargo fmt -- --check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          components: clippy, rustfmt
+      - name: Compile
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --tests
+      - name: Compile with all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --tests --all-features

--- a/lumeo_api_client/Cargo.toml
+++ b/lumeo_api_client/Cargo.toml
@@ -18,3 +18,8 @@ serde_with = "1.12.1"
 strum = { version = "0.24.0", features = ["derive"] }
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["serde"] }
+# This allows deriving `sqlx::Type` to share types with `api-server`.
+sqlx = {version = "0.5.13", default-features = false, features = ["macros", "runtime-tokio-rustls"], optional = true }
+
+[features]
+api-server = ["sqlx"]

--- a/lumeo_api_client/src/pipeline/node_properties/video_source_properties.rs
+++ b/lumeo_api_client/src/pipeline/node_properties/video_source_properties.rs
@@ -125,6 +125,7 @@ impl CameraRuntime {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InputStreamRuntime {
+    File(InputFileStreamRuntime),
     Rtsp(InputRtspStreamRuntime),
     WebRtc(InputWebRtcStreamRuntime),
 }
@@ -133,16 +134,18 @@ impl InputStreamRuntime {
     pub fn uri(&self) -> Option<&Url> {
         use InputStreamRuntime::*;
         match self {
+            File(InputFileStreamRuntime { uri, .. }) => Some(uri),
             Rtsp(InputRtspStreamRuntime { uri, .. }) => Some(uri),
-            _ => None,
+            WebRtc(_) => None,
         }
     }
 
     pub fn name(&self) -> Option<&str> {
         use InputStreamRuntime::*;
         match self {
+            File(InputFileStreamRuntime { name, .. }) => Some(name),
             Rtsp(InputRtspStreamRuntime { name, .. }) => Some(name),
-            _ => None,
+            WebRtc(_) => None,
         }
     }
 }
@@ -183,6 +186,17 @@ pub struct InputRtspStreamRuntime {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputWebRtcStreamRuntime {
     // TODO: define how do we use WebRTC streams as inputs
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InputFileStreamRuntime {
+    /// File stream URI.
+    ///
+    /// Example: "file:///home/lumeo/file.mp4"
+    pub uri: Url,
+
+    /// Stream name.
+    pub name: String,
 }
 
 // FIXME: replace manual deserialization with

--- a/lumeo_api_client/src/streams.rs
+++ b/lumeo_api_client/src/streams.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, EnumString};
 use url::Url;
 use uuid::Uuid;
 
@@ -9,12 +10,12 @@ use crate::Result;
 #[derive(Serialize)]
 pub struct StreamData {
     pub name: Option<String>,
-    pub source: String,
-    pub stream_type: String,
+    pub source: StreamSource,
+    pub stream_type: StreamType,
     #[serde(rename = "device_id")]
     pub gateway_id: Option<Uuid>,
-    pub uri: Option<Url>,
-    pub status: Option<String>,
+    pub uri: Url,
+    pub status: Option<StreamStatus>,
     pub camera_id: Option<Uuid>,
     pub deployment_id: Option<Uuid>,
     pub node: Option<String>,
@@ -29,8 +30,8 @@ pub struct Stream {
     pub updated_at: DateTime<Utc>,
     pub application_id: Uuid,
     pub name: String,
-    pub source: String,
-    pub stream_type: String,
+    pub source: StreamSource,
+    pub stream_type: StreamType,
     #[serde(alias = "device_id")]
     pub gateway_id: Option<Uuid>,
     pub uri: Option<Url>,
@@ -40,6 +41,38 @@ pub struct Stream {
     pub node: Option<String>,
     pub configuration: Option<String>,
     pub snapshot_file_id: Option<Uuid>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Debug, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "stream_type", rename_all = "snake_case"))]
+pub enum StreamType {
+    Rtsp,
+    Webrtc,
+    File,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Debug)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "stream_source", rename_all = "snake_case"))]
+pub enum StreamSource {
+    CameraStream,
+    UriStream,
+    PipelineStream,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Debug, AsRefStr)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "stream_status", rename_all = "snake_case"))]
+pub enum StreamStatus {
+    Online,
+    Offline,
+    Unknown,
 }
 
 impl Client {


### PR DESCRIPTION
Adds a new video source type `File` with the same contents as `Rtsp`.

Also updates the `Stream` and `StreamData` type and adds support for sharing types that derive `sqlx::Type` between this and `api-server`.