### PR TITLE
Split file stream into Uri filestreams and Lumeo file streams

### DIFF
--- a/lumeo_api_client/Cargo.toml
+++ b/lumeo_api_client/Cargo.toml
@@ -20,6 +20,7 @@ url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["serde"] }
 # This allows deriving `sqlx::Type` to share types with `api-server`.
 sqlx = {version = "0.5.13", default-features = false, features = ["macros", "runtime-tokio-rustls"], optional = true }
+vec1 = { version = "1.8.0", features = ["serde"]}
 
 [features]
 api-server = ["sqlx"]


### PR DESCRIPTION
This fixes two things over the previous version:

* Support for streams made from files uploaded to our API. (`LumeoFile`). They are represented by a `file_id` instead of a URL because the presigned S3 URLs expire after some time.
* Support for multiple files in a file stream. E.g. if a customer has their videos in 1 hour chunks but wants to run a deployment on 24 hours of video. api-server will initially prevent creating file streams with multiple files, but this can be then unlocked at a later date once lumeod supports it.

