### PR TITLE
Add support for the file stream API

### DIFF
--- a/lumeo_api_client/Cargo.toml
+++ b/lumeo_api_client/Cargo.toml
@@ -24,3 +24,7 @@ vec1 = { version = "1.8.0", features = ["serde"]}
 
 [features]
 api-server = ["sqlx"]
+
+[dev-dependencies]
+uuid = { version = "1.0.0", features = ["serde", "v4"] }
+assert-json-diff = "2"

--- a/lumeo_api_client/src/streams.rs
+++ b/lumeo_api_client/src/streams.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, EnumString};
 use url::Url;
 use uuid::Uuid;
+use vec1::Vec1;
 
 use super::Client;
 use crate::Result;
@@ -14,7 +15,8 @@ pub struct StreamData {
     pub stream_type: StreamType,
     #[serde(rename = "device_id")]
     pub gateway_id: Option<Uuid>,
-    pub uri: Url,
+    #[serde(flatten)]
+    pub content: StreamContent,
     pub status: Option<StreamStatus>,
     pub camera_id: Option<Uuid>,
     pub deployment_id: Option<Uuid>,
@@ -34,13 +36,21 @@ pub struct Stream {
     pub stream_type: StreamType,
     #[serde(alias = "device_id")]
     pub gateway_id: Option<Uuid>,
-    pub uri: Option<Url>,
+    #[serde(flatten)]
+    pub content: StreamContent,
     pub status: StreamStatus,
     pub camera_id: Option<Uuid>,
     pub deployment_id: Option<Uuid>,
     pub node: Option<String>,
     pub configuration: Option<String>,
     pub snapshot_file_id: Option<Uuid>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StreamContent {
+    Urls { urls: Vec1<Url> },
+    Files { file_ids: Vec1<Uuid> },
 }
 
 #[derive(Deserialize, Serialize, Clone, Copy, Eq, PartialEq, Debug, EnumString)]
@@ -84,5 +94,152 @@ impl Client {
     pub async fn read_stream(&self, stream_id: Uuid) -> Result<Stream> {
         let application_id = self.application_id()?;
         self.get(&format!("/v1/apps/{application_id}/streams/{stream_id}"), None::<&()>).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+    use vec1::vec1;
+
+    use super::*;
+
+    #[test]
+    fn stream_data_should_serialize_with_file_ids() {
+        let file_id = Uuid::new_v4();
+        let data = StreamData {
+            name: None,
+            source: StreamSource::UriStream,
+            stream_type: StreamType::File,
+            gateway_id: None,
+            content: StreamContent::Files { file_ids: vec1![file_id] },
+            status: None,
+            camera_id: None,
+            deployment_id: None,
+            node: None,
+            configuration: None,
+            snapshot_file_id: None,
+        };
+
+        let expected_json = json!({
+            "name": null,
+            "source": "uri_stream",
+            "stream_type": "file",
+            "device_id": null,
+            "file_ids": [file_id],
+            "status": null,
+            "camera_id": null,
+            "deployment_id": null,
+            "node": null,
+            "configuration": null,
+            "snapshot_file_id": null,
+        });
+
+        assert_json_eq!(expected_json, data);
+    }
+
+    #[test]
+    fn stream_data_should_deserialize_with_file_ids() {
+        let file_id = Uuid::new_v4();
+        let json = json!({
+            "name": null,
+            "source": "uri_stream",
+            "stream_type": "file",
+            "device_id": null,
+            "status": "online",
+            "file_ids": [file_id],
+            "status": null,
+            "camera_id": null,
+            "deployment_id": null,
+            "node": null,
+            "configuration": null,
+            "snapshot_file_id": null,
+        });
+
+        let expected_data = StreamData {
+            name: None,
+            source: StreamSource::UriStream,
+            stream_type: StreamType::File,
+            gateway_id: None,
+            content: StreamContent::Files { file_ids: vec1![file_id] },
+            status: None,
+            camera_id: None,
+            deployment_id: None,
+            node: None,
+            configuration: None,
+            snapshot_file_id: None,
+        };
+
+        assert_json_eq!(expected_data, json);
+    }
+
+    #[test]
+    fn stream_data_should_serialize_with_urls() {
+        let url = Url::parse("file:///example.mp4").expect("Failed to parse URL");
+        let data = StreamData {
+            name: None,
+            source: StreamSource::UriStream,
+            stream_type: StreamType::File,
+            gateway_id: None,
+            content: StreamContent::Urls { urls: vec1![url.clone()] },
+            status: None,
+            camera_id: None,
+            deployment_id: None,
+            node: None,
+            configuration: None,
+            snapshot_file_id: None,
+        };
+
+        let expected_json = json!({
+            "name": null,
+            "source": "uri_stream",
+            "stream_type": "file",
+            "device_id": null,
+            "urls": [url],
+            "status": null,
+            "camera_id": null,
+            "deployment_id": null,
+            "node": null,
+            "configuration": null,
+            "snapshot_file_id": null,
+        });
+
+        assert_json_eq!(expected_json, data);
+    }
+
+    #[test]
+    fn stream_data_should_deserialize_with_urls() {
+        let url = Url::parse("file:///example.mp4").expect("Failed to parse URL");
+        let json = json!({
+            "name": null,
+            "source": "uri_stream",
+            "stream_type": "file",
+            "device_id": null,
+            "status": "online",
+            "urls": [url],
+            "status": null,
+            "camera_id": null,
+            "deployment_id": null,
+            "node": null,
+            "configuration": null,
+            "snapshot_file_id": null,
+        });
+
+        let expected_data = StreamData {
+            name: None,
+            source: StreamSource::UriStream,
+            stream_type: StreamType::File,
+            gateway_id: None,
+            content: StreamContent::Urls { urls: vec1![url] },
+            status: None,
+            camera_id: None,
+            deployment_id: None,
+            node: None,
+            configuration: None,
+            snapshot_file_id: None,
+        };
+
+        assert_json_eq!(expected_data, json);
     }
 }


### PR DESCRIPTION
This switches from the old `uri` field to the `urls` and `file_ids` fields.

Other than `StreamData` in `api-server`, this can use an `enum` to ensure only one of those is used and has always at least 1 element. (what currently prevents this in `api-server` is both the backwards compatibility to the old clients and being able to give better error messages).