### PR TITLE
Add `InputLumeoFileStreamRuntime::first_file_url`

### DIFF
--- a/lumeo_api_client/src/pipeline/node_properties/video_source_properties.rs
+++ b/lumeo_api_client/src/pipeline/node_properties/video_source_properties.rs
@@ -218,6 +218,8 @@ pub struct InputLumeoFileStreamRuntime {
     /// Lumeo file ids.
     /// Always has at least one element.
     pub file_ids: Vec1<Uuid>,
+    /// The first file URL. This value is set by lumeod.
+    pub first_file_url: Option<Url>,
 }
 
 // FIXME: replace manual deserialization with


### PR DESCRIPTION
I'm already setting `first_file_url` in `lumeod` before passing the pipeline to the `runner`. This way I could avoid implementing a new mechanism for requesting something from within the `runner`, which we'll need later though when the `runner` would support playing multiple files.