### PR TITLE
Add CommonClipProperties::prebuffer_interval

### DIFF
--- a/lumeo_api_client/src/pipeline/node_properties/clip_properties.rs
+++ b/lumeo_api_client/src/pipeline/node_properties/clip_properties.rs
@@ -17,6 +17,7 @@ pub struct CommonClipProperties {
     pub min_duration: Option<u64>,
     pub max_duration: Option<u64>,
     pub max_size: Option<u64>,
+    pub prebuffer_interval: Option<u64>,
     pub retention_duration: Option<u64>,
     pub webhook_url: Option<Url>,
     pub trigger: Option<String>,


### PR DESCRIPTION
This is for https://app.shortcut.com/lumeo/story/6469/allow-console-users-to-specify-pre-buffer-for-save-clip-node