### PR TITLE
Add login and error_events

### DIFF
--- a/lumeo_api_client/src/auth.rs
+++ b/lumeo_api_client/src/auth.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::Client;
+use crate::{
+    error::ErrorDetails, verify_response, Error::Reqwest, Method, Result, ResultExt,
+    DEFAULT_LOGIN_TIMEOUT,
+};
+
+#[derive(Serialize)]
+pub struct LoginParams {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LoginResponse {
+    pub token: String,
+}
+
+impl Client {
+    // This is an associated function rather than a method because `Client` is unfortunately build
+    // in a way that it needs to have an auth token to be created. We can't create a `Client`
+    // without having done a login first. For that to work we need to call the associated function
+    // `Client::login()` first in order to obtain a token and create `Client` from the returned token.
+    pub async fn login(server_address: String, login_params: LoginParams) -> Result<LoginResponse> {
+        let path = "/v1/internal/auth/login";
+        let url =
+            Url::parse(&format!("{server_address}{path}")).http_context(Method::POST, path)?;
+
+        let raw_reqwest_client =
+            reqwest::Client::builder().timeout(DEFAULT_LOGIN_TIMEOUT).build().map_err(|e| {
+                let status = e.status();
+                Reqwest(e, ErrorDetails { method: Method::POST, path: path.to_owned(), status })
+            })?;
+
+        let request_builder = raw_reqwest_client.post(url).json(&login_params);
+        verify_response(request_builder.send().await, Method::POST, path)
+            .await?
+            .json()
+            .await
+            .http_context(Method::POST, path)
+    }
+}

--- a/lumeo_api_client/src/events.rs
+++ b/lumeo_api_client/src/events.rs
@@ -38,9 +38,36 @@ pub struct Event {
     pub object_id: Option<Uuid>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GstErrorDomain {
+    Core = 1,
+    Library = 2,
+    Resource = 3,
+    Stream = 4,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ErrorData {
+    Deployment { deployment_id: Uuid, error: DeploymentError },
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DeploymentError {
+    GstError { domain: GstErrorDomain, code: i32 },
+}
+
 impl Client {
     pub async fn create_event(&self, event: &EventData) -> Result<Event> {
         let application_id = self.application_id()?;
         self.post(&format!("/v1/apps/{application_id}/events"), event).await
+    }
+
+    pub async fn create_error_event(&self, error_data: &ErrorData) -> Result<Event> {
+        let application_id = self.application_id()?;
+        self.post(&format!("/v1/internal/apps/{application_id}/events/error_events"), error_data)
+            .await
     }
 }

--- a/lumeo_api_client/src/lib.rs
+++ b/lumeo_api_client/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use uuid::Uuid;
 
 pub mod apps;
+pub mod auth;
 pub mod cameras;
 pub mod deployments;
 pub mod discovery_requests;
@@ -25,6 +26,7 @@ type Callback = Box<dyn Fn(&Error) + Send + Sync + 'static>;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_LOGIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct Client {
     http_client: reqwest::Client,


### PR DESCRIPTION
Those two where previously directly called from within lumeod.
After moving them into the `internal/` route in api-server it
was logical to use that opportunity to move them into api-client.