### PR TITLE
Add to and from string conversion for `events::Severity`

### DIFF
--- a/lumeo_api_client/src/events.rs
+++ b/lumeo_api_client/src/events.rs
@@ -1,12 +1,14 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use strum::{AsRefStr, EnumString};
 use uuid::Uuid;
 
 use super::Client;
 use crate::Result;
 
-#[derive(Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Deserialize, Serialize, AsRefStr, EnumString)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum Severity {
     Error,
     Warning,

--- a/lumeo_api_client/src/events.rs
+++ b/lumeo_api_client/src/events.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::Client;
 use crate::Result;
 
-#[derive(Clone, Copy, Eq, PartialEq, Deserialize, Serialize, AsRefStr, EnumString)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, AsRefStr, EnumString)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Severity {


### PR DESCRIPTION
We will pass `severity` from Python code as a string, so it's useful to have to/from `String` conversions.